### PR TITLE
Fix COMMIT reference in phantomjs-2.1.1.ebuild

### DIFF
--- a/www-client/phantomjs/phantomjs-2.1.1.ebuild
+++ b/www-client/phantomjs/phantomjs-2.1.1.ebuild
@@ -70,8 +70,8 @@ pkg_setup() {
 
 src_unpack() {
 	EGIT_REPO_URI="https://github.com/ariya/phantomjs.git"
-	EGIT_BRANCH="2.1"
-	EGIT_COMMIT="d9cda3dcd26b0e463533c5cc96e39c0f39fc32c1"
+	EGIT_BRANCH="master"
+	EGIT_COMMIT="8b26f54f7609a3b88164294f6332358246c39a16"
 	git-r3_fetch
 	git-r3_checkout
 


### PR DESCRIPTION
It seems the repo has changed some in the last year, and the previously referenced point in it no longer works. The new one should be equivalent.